### PR TITLE
[Fixed]`rails g`コマンドの際に、assets、helperが作成されないように修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,11 @@ module Achieve
     config.action_view.field_error_proc = proc { |html_tag, _| html_tag }
 
     config.generators do |g|
+	  g.assets     false
+	  g.helper     false
+	end
+
+    config.generators do |g|
       g.test_framework :rspec,
         fixtures: true,
         view_specs: false,

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,9 +26,9 @@ module Achieve
     config.action_view.field_error_proc = proc { |html_tag, _| html_tag }
 
     config.generators do |g|
-	  g.assets     false
-	  g.helper     false
-	end
+      g.assets     false
+      g.helper     false
+    end
 
     config.generators do |g|
       g.test_framework :rspec,


### PR DESCRIPTION
デフォルトで helper と assets ファイルが生成されないようにする

※こちらを参照
http://blog.willnet.in/entry/2012/09/02/220124
